### PR TITLE
Fix readmore functionality and add badge colours for the impact tex

### DIFF
--- a/statusphere-frontend/src/components/Outages.tsx
+++ b/statusphere-frontend/src/components/Outages.tsx
@@ -5,11 +5,26 @@ import {StatusPage} from "@/model/StatusPage";
 import {calculateDuration, convertToSimpleDate} from "@/utils/datetime";
 import {ReadMore} from "@/components/ReadMore";
 import {Card, CardDescription, CardHeader, CardTitle} from "@/components/ui/card";
+import {Badge} from "@/components/ui/badge";
 
 interface OutagesProps {
     statusPageDetails: StatusPage;
 }
+function getBadgeColour(impact: string) {
+    switch (impact) {
+        case "none":
+            return "bg-green-400";
+        case "minor":
+            return "bg-yellow-400";
+        case "major":
+            return "bg-red-400";
+        case "maintenance":
+            return "bg-blue-400";
+        default:
+            return "bg-gray-400";
+    }
 
+}
 export function Outages(props: OutagesProps) {
     const [incidents, setIncidents] = useState<Incident[]>([]);
 
@@ -76,7 +91,9 @@ export function Outages(props: OutagesProps) {
                 <TableRow>
                     <TableCell>{convertToSimpleDate(incident.startTime)}</TableCell>
                     <TableCell><a href={incident.deepLink}> {incident.title} </a></TableCell>
-                    <TableCell>{incident.impact}</TableCell>
+                    <TableCell>
+                        <Badge className={getBadgeColour(incident.impact)}>{incident.impact}</Badge>
+                    </TableCell>
                     <TableCell>{calculateDuration(incident.startTime, incident.endTime)}</TableCell>
                     {window.innerWidth > 500 && <TableCell className="text-left">
                         <ReadMore text={incident.description}/>

--- a/statusphere-frontend/src/components/ReadMore.tsx
+++ b/statusphere-frontend/src/components/ReadMore.tsx
@@ -11,7 +11,7 @@ export const ReadMore = ({text}: ReadMoreProps) => {
 
     return (
         <p>
-            {subText}...
+            {isExpanded ? text : subText + '...'}
             <span
                 className='text-gray-400 underline ml-2'
                 role="button"


### PR DESCRIPTION
- Nextjs setup
- Metoro Header and Footer added
- Shadcn components
- Outages and current status added with layout persisting on different pages
- Fixes
- E2E working with some style fixes
- Made service count text with custom colour
- Fix table sytle
- Fixes
- Fixes
- Fixes
- Fix eslint errors
- Fix build failures
- Fix basepath
- Fix readmore and add badge colours for impact
