### PR TITLE
adds VictoriaMetrics Cloud to the list of Status pages

### DIFF
--- a/common/status_pages/status_pages.go
+++ b/common/status_pages/status_pages.go
@@ -2217,7 +2217,7 @@ var StatusPages = []api.StatusPage{
 		Name: "Edg.io",
 	},
 	{
-		URL:  "https://status.victoriametrics.com/",
+		URL:  "https://status.victoriametrics.com",
 		Name: "Managed VictoriaMetrics",
 	},
 }

--- a/common/status_pages/status_pages.go
+++ b/common/status_pages/status_pages.go
@@ -2216,4 +2216,8 @@ var StatusPages = []api.StatusPage{
 		URL:  "https://status.edg.io/",
 		Name: "Edg.io",
 	},
+	{
+		URL:  "https://status.victoriametrics.com/",
+		Name: "Managed VictoriaMetrics",
+	},
 }


### PR DESCRIPTION
This PR will add https://status.victoriametrics.com to `common/status_pages/status_pagees.go`.